### PR TITLE
Destroy socket to close duplicated file descriptor

### DIFF
--- a/source/vibe/db/postgresql/package.d
+++ b/source/vibe/db/postgresql/package.d
@@ -110,7 +110,11 @@ class __Conn : dpq2.Connection
         auto sock = this.socket();
 
         sock.blocking = false;
-        scope(exit) sock.blocking = true;
+        scope(exit)
+        {
+            sock.blocking = true;
+            destroy(sock);
+        }
 
         auto event = createFileDescriptorEvent(sock.handle, FileDescriptorEvent.Trigger.any);
         scope(exit) destroy(event); // Prevents 100% CPU usage


### PR DESCRIPTION
Without destroying socket, it takes some time (GC collection run) until file descripto is closed. This cause issue with number of opened file descriptors.

For example in my case it could opened more than 1024 fds, which is limit for my system user.
With this change it has only 6 fds opened.