### PR TITLE
Fix #18

### DIFF
--- a/source/vibe/db/postgresql/package.d
+++ b/source/vibe/db/postgresql/package.d
@@ -105,15 +105,42 @@ class __Conn : dpq2.Connection
 
     private void waitEndOfRead(in Duration timeout) // TODO: rename to waitEndOf + add FileDescriptorEvent.Trigger argument
     {
+        // copy from the Phobos Socket implementation
+        bool isBlocking(int sock)
+        {
+            version(Windows)
+            {
+                //https://stackoverflow.com/a/5500906/5581403
+                return true; //we don't know and can't check
+            }
+            else version(Posix)
+            {
+                import core.sys.posix.fcntl;
+                return !(fcntl(sock, F_GETFL, 0) & O_NONBLOCK);
+            }
+        }
+
+        import std.socket : Socket;
         import vibe.core.core;
 
-        // Connection socket should be non-blocking while waiting
-        auto sock = this.socket();
-        sock.blocking = false;
+        Socket sock;
         scope(exit)
         {
-            sock.blocking = true;
-            destroy(sock);
+            if (sock !is null)
+            {
+                sock.blocking = true;
+                destroy(sock);
+                logDebugV("Socket set to blocking");
+            }
+        }
+
+        // check if connection socket is blocking
+        if (isBlocking(this.posixSocket))
+        {
+            // Connection socket should be non-blocking while waiting
+            sock = this.socket();
+            sock.blocking = false;
+            logDebugV("Socket set to non-blocking");
         }
 
         version(Have_vibe_core)
@@ -122,21 +149,27 @@ class __Conn : dpq2.Connection
             enum trigger = FileDescriptorEvent.Trigger.read;
 
             // vibe-core does reference counting and closes socket
-            // after it are used.
+            // after it is used.
             // Thus we need to a copy of socket for it.
             auto posix_socket = cast(int) posixSocketDuplicate;
         }
         else
         {
             enum trigger = FileDescriptorEvent.Trigger.any;
-            auto posix_socket = sock.handle;
+            auto posix_socket = sock is null ? this.posixSocket : sock.handle;
         }
 
         auto event = createFileDescriptorEvent(posix_socket, trigger);
         scope(exit) destroy(event); // Prevents 100% CPU usage
 
-        if(!event.wait(timeout))
-            throw new PostgresClientTimeoutException(__FILE__, __LINE__);
+        do
+        {
+            if(!event.wait(timeout))
+                throw new PostgresClientTimeoutException(__FILE__, __LINE__);
+
+            consumeInput();
+        }
+        while (this.isBusy); // wait untill PQgetresult won't block anymore
     }
 
     private void doQuery(void delegate() doesQueryAndCollectsResults)


### PR DESCRIPTION
I've tested this against the test case mentioned in the issue and also in my REST service itself and it seems to work ok.

But I'm not sure about some things in the code:
1) why is there need to dup the socket in the first place to set it nonblocking? Can't we use the PQsocket handle directly?
2) Windows support - it is broken currently by https://github.com/denizzzka/dpq2/blob/master/src/dpq2/connection.d#L137
3) Windows support to check the blocking/non-blocking status of socket - I didn't find a way to check it and it is also not checked in phobos - see https://github.com/dlang/phobos/blob/master/std/socket.d#L2714 - it only uses thi internal flag for it, so we can't actually check if windows socket is blocking or not and if we assume it is, we will possibly switch it to blocking afterwards event it was nonblocking previously
4) I don't understand this line https://github.com/denizzzka/vibe.d.db.postgresql/blob/42395993e06ebb21ad99e13e6685f38d01c56aa0/source/vibe/db/postgresql/package.d#L127
Where is a refcounting used when we work here with std.socket.Socket? And actually why is there made a duplicated Socket to set nonblocking mode and then here made another one (which is not closed afterwards) which is used to create event?