### PR TITLE
Remove unnecessary destruction of locked connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ PostgresClient client;
 void test()
 {
     auto conn = client.lockConnection();
-    scope(exit) destroy(conn);
 
     try
     {


### PR DESCRIPTION
Locked connections are structs, and auto-destructed on scope exit. Adding a destroy is pointless, but those who are using the library may not know this and keep adding these unnecessarily into their apps (I just realized I was making an app and had this unnecessary line copied from the example).