### PR TITLE
Avoid busy wait on connection reset

### DIFF
--- a/source/vibe/db/postgresql/package.d
+++ b/source/vibe/db/postgresql/package.d
@@ -270,7 +270,6 @@ class Dpq2Connection : dpq2.Connection
 
                     while(true)
                     {
-                        logDebugV("getResult()");
                         auto r = getResult();
 
                         /*


### PR DESCRIPTION
Original `waitEndOfRead` just returned filedescriptor event from vibe-core that weren't used in the reset loop at all so it was actually busy waiting.