### PR TITLE
Eliminates names inconsistency with the names of the dpq2 methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
   ci:
     name: '[ci] ${{ matrix.dc }}/${{ matrix.build }}'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: setup
     # Only run if the setup phase explicitly defined compilers to be used
     if: ${{ fromJSON(needs.setup.outputs.compilers) != '' && fromJSON(needs.setup.outputs.compilers) != '[]' }}

--- a/.github/workflows/compilers.json
+++ b/.github/workflows/compilers.json
@@ -1,7 +1,10 @@
 [
+  "dmd-master",
   "dmd-latest",
-  "dmd-2.100.2",
-  "dmd-2.098.1",
+  "dmd-beta",
+  "dmd-2.105.3",
+  "ldc-master",
   "ldc-latest",
-  "ldc-1.28.1"
+  "ldc-beta",
+  "ldc-1.35.0"
 ]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ void test()
     client.pickConnection(
         (scope conn)
         {
-            immutable result = conn.execStatement(
+            immutable result = conn.exec(
                 "SELECT 123 as first_num, 567 as second_num, 'abc'::text as third_text "~
                 "UNION ALL "~
                 "SELECT 890, 233, 'fgh'::text as third_text",
@@ -36,7 +36,7 @@ void test()
     );
 }
 
-static this()
+void main()
 {
     // params: conninfo string, maximum number of connections in
     // the connection pool

--- a/dub.sdl
+++ b/dub.sdl
@@ -25,7 +25,6 @@ subPackage {
     name "example"
     sourcePaths "example"
     targetType "executable"
-    versions "VibeDefaultMain"
     dependency "vibe-d" version="*"
     dependency "vibe-d-postgresql" version="*"
 }

--- a/example/example.d
+++ b/example/example.d
@@ -10,7 +10,7 @@ void test()
     client.pickConnection(
         (scope conn)
         {
-            immutable result = conn.execStatement(
+            immutable result = conn.exec(
                 "SELECT 123 as first_num, 567 as second_num, 'abc'::text as third_text "~
                 "UNION ALL "~
                 "SELECT 890, 233, 'fgh'::text as third_text",
@@ -26,7 +26,7 @@ void test()
     );
 }
 
-static this()
+void main()
 {
     // params: conninfo string, maximum number of connections in
     // the connection pool

--- a/source/vibe/db/postgresql/query.d
+++ b/source/vibe/db/postgresql/query.d
@@ -1,0 +1,141 @@
+///
+module vibe.db.postgresql.query;
+
+import vibe.db.postgresql;
+
+mixin template Queries()
+{
+    /// Perform SQL query to DB
+    /// All values are returned in textual
+    /// form. This means that the dpq2.conv.to_d_types.as template will likely
+    /// not work for anything but strings.
+    /// Try to use exec(string, ValueFormat.BINARY) or execParams(QueryParams) instead, even if now parameters are present.
+    override immutable(Answer) exec(string sqlCommand)
+    {
+        return exec(sqlCommand, ValueFormat.TEXT);
+    }
+
+    ///
+    immutable(Answer) exec(
+        string sqlCommand,
+        ValueFormat resultFormat
+    )
+    {
+        QueryParams p;
+        p.resultFormat = resultFormat;
+        p.sqlCommand = sqlCommand;
+
+        return execParams(p);
+    }
+
+    /// Perform SQL query to DB
+    override immutable(Answer) execParams(scope const ref QueryParams params)
+    {
+        auto res = runStatementBlockingManner({ sendQueryParams(params); });
+
+        return res.getAnswer;
+    }
+
+    /// Row-by-row version of exec
+    ///
+    /// Delegate called for each received row.
+    ///
+    /// More info: https://www.postgresql.org/docs/current/libpq-single-row-mode.html
+    ///
+    void execStatementRbR(
+        string sqlCommand,
+        void delegate(immutable(Row)) answerRowProcessDg,
+        ValueFormat resultFormat = ValueFormat.BINARY
+    )
+    {
+        QueryParams p;
+        p.resultFormat = resultFormat;
+        p.sqlCommand = sqlCommand;
+
+        execStatementRbR(p, answerRowProcessDg);
+    }
+
+    /// Row-by-row version of execParams
+    ///
+    /// Delegate called for each received row.
+    ///
+    /// More info: https://www.postgresql.org/docs/current/libpq-single-row-mode.html
+    ///
+    void execStatementRbR(scope const ref QueryParams params, void delegate(immutable(Row)) answerRowProcessDg)
+    {
+        runStatementWithRowByRowResult(
+            { sendQueryParams(params); },
+            answerRowProcessDg
+        );
+    }
+
+    /// Submits a request to create a prepared statement with the given parameters, and waits for completion.
+    ///
+    /// Throws an exception if preparing failed.
+    void prepareEx(
+        string statementName,
+        string sqlStatement,
+        Oid[] oids = null
+    )
+    {
+        auto r = runStatementBlockingManner(
+                {sendPrepare(statementName, sqlStatement, oids);}
+            );
+
+        if(r.status != PGRES_COMMAND_OK)
+            throw new ResponseException(r, __FILE__, __LINE__);
+    }
+
+    /// Submits a request to execute a prepared statement with given parameters, and waits for completion.
+    override immutable(Answer) execPrepared(scope const ref QueryParams params)
+    {
+        auto res = runStatementBlockingManner({ sendQueryPrepared(params); });
+
+        return res.getAnswer;
+    }
+
+    /// Submits a request to obtain information about the specified prepared statement, and waits for completion.
+    override immutable(Answer) describePrepared(string preparedStatementName)
+    {
+        auto res = runStatementBlockingManner({ sendDescribePrepared(preparedStatementName); });
+
+        return res.getAnswer;
+    }
+
+    deprecated("please use exec(sqlCommand, ValueFormat.BINARY) instead. execStatement() will be removed by 2027")
+    immutable(Answer) execStatement(
+        string sqlCommand,
+        ValueFormat resultFormat = ValueFormat.BINARY
+    )
+    {
+        return exec(sqlCommand, resultFormat);
+    }
+
+    deprecated("please use execParams() instead. execStatement() will be removed by 2027")
+    immutable(Answer) execStatement(scope const ref QueryParams params)
+    {
+        return execParams(params);
+    }
+
+    deprecated("please use prepareEx() instead. prepareStatement() will be removed by 2027")
+    void prepareStatement(
+        string statementName,
+        string sqlStatement,
+        Oid[] oids = null
+    )
+    {
+        prepareEx(statementName, sqlStatement, oids);
+    }
+
+    deprecated("please use execPrepared() instead. execPreparedStatement() will be removed by 2027")
+    immutable(Answer) execPreparedStatement(scope const ref QueryParams params)
+    {
+        return execPrepared(params);
+    }
+
+    deprecated("please use describePrepared() instead. describePreparedStatement() will be removed by 2027")
+    immutable(Answer) describePreparedStatement(string preparedStatementName)
+    {
+        return describePrepared(preparedStatementName);
+    }
+}


### PR DESCRIPTION
It was found that users confusing methods names provided by base `dpq2` package and by `vibe.d.db.postgresql`: they tried to use `exec()` on `vibe.db.postgresql` connection class, and so.

This PR makes the names the same as in `dpq2`

Deprecation messages was added
